### PR TITLE
Fixes for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2
 jobs:
     py27:
         working_directory: /circleci

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,5 +33,5 @@ test:
 about:
     home: https://github.com/coecms/mdssdiff
     license: Apache 2.0
-    license_file: LICENSE-2.0.txt
+    license_file: LICENSE
     summary: Report difference between directory tree on a local filesystem and on a remote mass data store. Some rudimentary synching supported.

--- a/test/test_mdssdiff.py
+++ b/test/test_mdssdiff.py
@@ -37,7 +37,7 @@ paths = [ ["1","lala"], ["1","po"], ["1","2","Mickey"], ["1","2","Minny"], ["1",
 prefix = "test_mdss"
 dirtreeroot = dirs[0]
 verbose=False
-project=os.environ['PROJECT']
+project=os.environ.get('PROJECT','a12')
 
 def touch(fname, times=None):
     # http://stackoverflow.com/a/1160227/4727812


### PR DESCRIPTION
Tests involving MDSS will still fail, as it is not available outside of Raijin.

I'd work around this by creating functions for mdss commands, e.g.
```
# mdss.py
def put(source, dest, project):
    subprocess.call(['mdss','-P',project,source,dest])
```

then in the tests use the [`mock`](https://pypi.python.org/pypi/mock) package to make sure it's called the correct way
```
# test_mdssdiff
def test_put():
    with mock.patch('mdss.put') as mock_put:
        # Something to test
        # ...

        # Check the put got called
        mock_put.assert_called_with('expectedsrc', 'expecteddest')
```